### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.1+3] - May 23, 2023
+
+* Automated dependency updates
+
+
 ## [4.0.1+2] - February 7, 2023
 
 * Automated dependency updates
@@ -176,6 +181,7 @@
 ## [1.0.0] - January 11th, 2022
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,28 +1,29 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+2'
+version: '1.0.0+3'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
-  http: '^0.13.5'
-  json_dynamic_widget_plugin_markdown:
+  http: '^1.0.0'
+  json_dynamic_widget_plugin_markdown: 
     path: '../'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-flutter:
+
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/pages/'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,37 +1,39 @@
 name: 'json_dynamic_widget_plugin_markdown'
 description: 'A plugin to the JSON Dynamic Widget to provide support for Markdown'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_markdown'
-version: '4.0.1+2'
+version: '4.0.1+3'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
-  flutter:
+  flutter: 
     sdk: 'flutter'
-  flutter_markdown: '^0.6.13+1'
-  intl: '^0.18.0'
-  json_class: '^2.1.5+1'
-  json_dynamic_widget: '^6.0.4'
-  json_theme: '^5.0.0+2'
+  flutter_markdown: '^0.6.14'
+  intl: '^0.18.1'
+  json_class: '^2.2.1+3'
+  json_dynamic_widget: '^6.0.5+1'
+  json_theme: '^5.0.2+6'
   logging: '^1.1.1'
-  markdown: '^6.0.1'
+  markdown: '^7.1.0'
   meta: '^1.8.0'
   uuid: '^3.0.7'
 
-false_secrets:
+false_secrets: 
   - 'example/web/index.html'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_markdown`: 0.6.13+1 --> 0.6.14
  * `intl`: 0.18.0 --> 0.18.1
  * `json_class`: 2.1.5+1 --> 2.2.1+3
  * `json_dynamic_widget`: 6.0.4 --> 6.0.5+1
  * `json_theme`: 5.0.0+2 --> 5.0.2+6
  * `markdown`: 6.0.1 --> 7.1.0


Analysis Successful


dependencies:
  * `http`: 0.13.5 --> 1.0.0


Error!!!
```
Resolving dependencies...


Because every version of json_dynamic_widget_plugin_markdown from path depends on json_dynamic_widget ^6.0.5+1 which depends on json_schema2 ^2.0.4+5, every version of json_dynamic_widget_plugin_markdown from path requires json_schema2 ^2.0.4+5.
And because json_schema2 >=2.0.4+4 depends on rest_client ^2.2.1+11 which depends on http ^0.13.6, every version of json_dynamic_widget_plugin_markdown from path requires http ^0.13.6.
So, because example depends on both http ^1.0.0 and json_dynamic_widget_plugin_markdown from path, version solving failed.

```

