### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0+17] - November 26, 2024
+
+* Automated dependency updates
+
+
 ## [5.0.0+16] - July 16, 2024
 
 * Automated dependency updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,30 +1,30 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+12'
+version: '1.0.0+13'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  flutter: 
+dependencies:
+  flutter:
     sdk: 'flutter'
   http: '^1.2.2'
-  json_dynamic_widget: '^7.2.0+6'
-  json_dynamic_widget_plugin_markdown: 
+  json_dynamic_widget: '^7.3.1+10'
+  json_dynamic_widget_plugin_markdown:
     path: '../'
-  logging: '^1.2.0'
+  logging: '^1.3.0'
 
-dev_dependencies: 
-  flutter_test: 
+dev_dependencies:
+  flutter_test:
     sdk: 'flutter'
 
-flutter: 
+flutter:
   uses-material-design: true
-  assets: 
+  assets:
     - 'assets/pages/'
 
-permittedLicenses: 
+permittedLicenses:
   - 'Apache-2.0'
   - 'BSD-2-Clause'
   - 'BSD-3-Clause'
@@ -33,7 +33,7 @@ permittedLicenses:
   - 'MPL-2.0'
   - 'Zlib'
 
-packageLicenseOverride: 
+packageLicenseOverride:
   flutter: 'BSD-3-Clause'
   flutter_driver: 'BSD-3-Clause'
   flutter_goldens: 'BSD-3-Clause'
@@ -44,7 +44,7 @@ packageLicenseOverride:
   integration_test: 'BSD-3-Clause'
   rxdart: 'Apache-2.0'
 
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_markdown'
 description: 'A plugin to the JSON Dynamic Widget to provide support for Markdown'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_markdown'
-version: '5.0.0+16'
+version: '5.0.0+17'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -15,25 +15,25 @@ dependencies:
   child_builder: '^2.0.2'
   flutter:
     sdk: 'flutter'
-  flutter_markdown: '^0.7.3'
-  intl: '^0.19.0'
+  flutter_markdown: '^0.7.4+2'
+  intl: '^0.20.0'
   json_class: '^3.0.0+16'
-  json_dynamic_widget: '^7.2.0+6'
-  json_theme: '^6.5.0+1'
-  logging: '^1.2.0'
+  json_dynamic_widget: '^7.3.1+10'
+  json_theme: '^6.5.3+6'
+  logging: '^1.3.0'
   markdown: '^7.2.2'
   meta: '^1.12.0'
-  uuid: '^4.4.2'
+  uuid: '^4.5.1'
 
 false_secrets:
   - 'example/web/index.html'
 
 dev_dependencies:
-  build_runner: '^2.4.11'
+  build_runner: '^2.4.13'
   flutter_lints: '^5.0.0'
   flutter_test:
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+4'
+  json_dynamic_widget_codegen: '^1.0.6+15'
 
 permittedLicenses:
   - 'Apache-2.0'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `flutter_markdown`: 0.7.3 --> 0.7.4+2
  * `intl`: 0.19.0 --> 0.20.0
  * `json_dynamic_widget`: 7.2.0+6 --> 7.3.1+10
  * `json_theme`: 6.5.0+1 --> 6.5.3+6
  * `logging`: 1.2.0 --> 1.3.0
  * `uuid`: 4.4.2 --> 4.5.1

dev_dependencies:
  * `build_runner`: 2.4.11 --> 2.4.13
  * `json_dynamic_widget_codegen`: 1.0.6+4 --> 1.0.6+15


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/to/crash-reporting                                     ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...


Because json_class >=3.0.0+9 depends on intl ^0.19.0 and json_dynamic_widget_plugin_markdown depends on intl ^0.20.0, json_class >=3.0.0+9 is forbidden.
So, because json_dynamic_widget_plugin_markdown depends on json_class ^3.0.0+16, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on intl: flutter pub add intl:^0.19.0

```


dependencies:
  * `json_dynamic_widget`: 7.2.0+6 --> 7.3.1+10
  * `logging`: 1.2.0 --> 1.3.0


Error!!!
```
Resolving dependencies...


Because json_class >=3.0.0+9 depends on intl ^0.19.0 and every version of json_dynamic_widget_plugin_markdown from path depends on intl ^0.20.0, json_class >=3.0.0+9 is incompatible with json_dynamic_widget_plugin_markdown from path.
And because json_dynamic_widget >=7.2.2+1 depends on json_class ^3.0.0+16, json_dynamic_widget >=7.2.2+1 is incompatible with json_dynamic_widget_plugin_markdown from path.
So, because example depends on both json_dynamic_widget ^7.3.1+10 and json_dynamic_widget_plugin_markdown from path, version solving failed.

```

